### PR TITLE
Fix URL escaping bug in location.ejs

### DIFF
--- a/views/location.ejs
+++ b/views/location.ejs
@@ -84,7 +84,7 @@
     
   </div>
 
-  <p><a href=\"/user/<%= sessionUser.user_id %>\">← ダッシュボードへ戻る</a></p>
+  <p><a href="/user/<%= sessionUser.user_id %>">← ダッシュボードへ戻る</a></p>
 
 <!-- アイテム編集ポップアップ -->
 <div id="editItemModal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); z-index:1000;">


### PR DESCRIPTION
## Summary
- Fixed URL escaping bug in location view dashboard return link

## Problem
The dashboard return link in `views/location.ejs` was incorrectly escaped with `\"` quotes, causing URL display issues.

**Before:**
```html
<a href=\"/user/<%= sessionUser.user_id %>\">← ダッシュボードへ戻る</a>
```

**After:**
```html
<a href="/user/<%= sessionUser.user_id %>">← ダッシュボードへ戻る</a>
```

## Details
- **Issue**: URLs were displaying with escaped quotes in the browser
- **Root Cause**: Incorrect escaping of href attribute quotes in EJS template
- **Solution**: Removed unnecessary escape characters from href attribute
- **Impact**: Fixes navigation link display and functionality

## Files Modified
- `views/location.ejs` - Fixed escaped quotes in dashboard return link

## Testing
- [x] Verified link displays correctly without escaped quotes
- [x] Confirmed navigation functionality works properly
- [x] Checked for similar issues in other view files (none found)

This is a critical bug fix that affects user navigation experience.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>